### PR TITLE
Create first release of libcamera-ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 # v1.190.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3'] # Explicitly not supporting 2.7
 
     steps:
     - uses: actions/checkout@v4
@@ -35,4 +35,4 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
-      run: bundle exec rake test
+      run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
+    mini_portile2 (2.8.7)
     minitest (5.25.1)
     minitest-focus (1.4.0)
       minitest (>= 4, < 6)
@@ -68,7 +69,12 @@ GEM
     mocha (2.4.5)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.2.0)
+    nokogiri (1.16.5)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -95,6 +101,8 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  ruby
+  x86_64-linux
 
 DEPENDENCIES
   libcamera!

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ To run tests execute:
 
     $ rake test
 
+## Building
+The build the gem locally:
+
+    $ gem build libcamera.gemspec
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/trex22/libcamera. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/bin/make
+++ b/bin/make
@@ -1,4 +1,4 @@
 #!/bin/bash
 bundle
 gem build libcamera.gemspec
-gem push libcamera
+# gem push libcamera

--- a/bin/setup
+++ b/bin/setup
@@ -5,4 +5,8 @@ set -vx
 
 bundle install
 
-# Do any other automated setup that you need to do here
+bundle lock --add-platform arm64-darwin
+bundle lock --add-platform x86_64-linux
+bundle lock --add-platform ruby
+
+bundle install


### PR DESCRIPTION
# What does this PR do?
- Fixes tests
- Build out initial interfaces to be used to control a raspberry PI camera via cli
- Moar tests
- Release tag